### PR TITLE
Change Swish from lambda fn to nn.Module class so swish-based models can be saved

### DIFF
--- a/eqv_transformer/eqv_attention.py
+++ b/eqv_transformer/eqv_attention.py
@@ -8,7 +8,7 @@ import torch.nn.functional as F
 from einops.einops import rearrange, reduce
 
 from lie_conv.lieGroups import SE3
-from lie_conv.lieConv import Swish
+from eqv_transformer.utils import Swish
 from lie_conv.utils import Pass, Expression
 from lie_conv.masked_batchnorm import MaskBatchNormNd
 from eqv_transformer.multihead_neural import (

--- a/eqv_transformer/multihead_neural.py
+++ b/eqv_transformer/multihead_neural.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 import torch
 from torch import nn
 
-from lie_conv.lieConv import Swish
+from eqv_transformer.utils import Swish
 from lie_conv.masked_batchnorm import MaskBatchNormNd
 from lie_conv.utils import Pass
 

--- a/eqv_transformer/utils.py
+++ b/eqv_transformer/utils.py
@@ -48,5 +48,11 @@ class GlobalPool(nn.Module):
         return summed
 
 
-def Swish():
-    return Expression(lambda x: x * torch.sigmoid(x))
+class Swish(nn.Module):
+    """Swish activation function"""
+    def __init__(self):
+        super(Swish, self).__init__()
+        self.sigmoid = nn.Sigmoid()
+
+    def forward(self, x):
+        return x * self.sigmoid(x)


### PR DESCRIPTION
Models which used the lambda-based swish could not be pickled/saved, so
an nn.Module is needed.